### PR TITLE
ci: cache node modules

### DIFF
--- a/.github/workflows/app_workflow.yaml
+++ b/.github/workflows/app_workflow.yaml
@@ -16,11 +16,6 @@ jobs:
         uses: actions/checkout@v2
         with: 
           fetch-depth: 0
-      - name: Setup Node
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-          cache: yarn
       - name: Get tags
         id: tag
         run: |
@@ -32,6 +27,11 @@ jobs:
             echo "Version: ${{ steps.tag.outputs.TAG }} needs to be updated in package.json" 
             exit 1
           fi 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          cache: yarn
       - name: Install node modules
         run: yarn install
       - name: Generate Sonarqube reports
@@ -62,8 +62,6 @@ jobs:
           cache: yarn
       - name: Install Node Modules
         run: yarn install
-      - name: Install Ruby
-        run: brew install ruby
       - name: Install Cocoapods
         run: gem install cocoapods
       - name: Install Pod dependencies
@@ -134,8 +132,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FILE: ios-artifact/ReactNativeSemaphoreNew
           GITHUB_REPOSITORY: ${{ env.GITHUB_REPO }}
-           
-
-
-       
-


### PR DESCRIPTION
the node-setup action has a built in option to cache node modules using yarn. this makes it easier to be consistent across the 3 jobs that use node and removed a dependency on a community action.

also removed a couple brew install steps that were installing tools that already exist on the runners